### PR TITLE
START is also a transaction command (equivalent to BEGIN)

### DIFF
--- a/src/IntlConnection.ts
+++ b/src/IntlConnection.ts
@@ -110,7 +110,7 @@ export class IntlConnection extends SafeEventEmitter {
     this.assertConnected();
     return this.statementQueue
         .enqueue(async (): Promise<ScriptResult> => {
-          const transactionCommand = sql.match(/^(\bBEGIN\b|\bCOMMIT\b|\bROLLBACK|SAVEPOINT|RELEASE\b)/i);
+          const transactionCommand = sql.match(/^(\bBEGIN\b|\bCOMMIT\b|\bSTART\b|\bROLLBACK|SAVEPOINT|RELEASE\b)/i);
           let beginFirst = false;
           let commitLast = false;
           if (!transactionCommand) {

--- a/src/PreparedStatement.ts
+++ b/src/PreparedStatement.ts
@@ -128,7 +128,7 @@ export class PreparedStatement extends SafeEventEmitter {
     debug("[%s] execute", this.name);
     const intlCon = getIntlConnection(this.connection);
 
-    const transactionCommand = this.sql.match(/^(\bBEGIN\b|\bCOMMIT\b|\bROLLBACK|SAVEPOINT|RELEASE\b)/i);
+    const transactionCommand = this.sql.match(/^(\bBEGIN\b|\bCOMMIT\b|\bSTART\b|\bROLLBACK|SAVEPOINT|RELEASE\b)/i);
     let beginFirst = false;
     let commitLast = false;
     if (!transactionCommand) {


### PR DESCRIPTION
Attempting to `START TRANSACTION` will trigger an 'savepoint sp_.... does not exist' error as postgresql-client does not recognize the keyword START as starting a transaction. (it looks for BEGIN instead)

According to https://www.postgresql.org/docs/current/sql-begin.html 'BEGIN' is actually the PG Extension and 'START' is in the SQL standard.

This PR modifies the client to simply accept both.