### PR TITLE
export SmartBuffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,5 @@ export * from './util/escape-literal.js';
 export * from './util/parse-datetime.js';
 export * from './util/stringify-arrayliteral.js';
 export * from './util/stringify-for-sql.js';
+
+export type { SmartBuffer } from "./protocol/smart-buffer";


### PR DESCRIPTION
The SmartBuffer type is needed when implementing an EncodeBinaryFunction in TypeScript. (just the type, not the actual constructor - I can workaround using a `@ts-ignore`)