### PR TITLE
Avoid os.cpus() calls

### DIFF
--- a/src/connection/cursor.ts
+++ b/src/connection/cursor.ts
@@ -1,5 +1,5 @@
 import DoublyLinked from 'doublylinked';
-import { TaskQueue } from 'power-tasks';
+import { Task, TaskQueue } from 'power-tasks';
 import { FieldInfo } from '../interfaces/field-info.js';
 import { QueryOptions } from '../interfaces/query-options.js';
 import { SafeEventEmitter } from '../safe-event-emitter.js';
@@ -73,7 +73,7 @@ export class Cursor extends SafeEventEmitter {
     if (this._closed) return;
     const portal = this._portal;
     await this._taskQueue
-        .enqueue(async () => {
+        .enqueue(new Task(async () => {
           const queryOptions = this._queryOptions;
           const r = await portal.execute(queryOptions.fetchCount || 100);
           if (r && r.rows && r.rows.length) {
@@ -92,7 +92,7 @@ export class Cursor extends SafeEventEmitter {
           } else {
             await this.close();
           }
-        })
+        }, { concurrency: 1 }))
         .toPromise();
   }
 }


### PR DESCRIPTION
We noticed in profiling that power-tasks will invoke os.cpus() on every created task, even though the taskqueue is fixed at concurrency 1 anyway. It accounts for 3 to 5% CPU usage on some of my benchmarks, so this seems like an easy win

(TBH: this should probably be fixed upstream but we didn't look into that)