### PR TITLE
export numberBytesToString

### DIFF
--- a/src/data-types/numeric-type.ts
+++ b/src/data-types/numeric-type.ts
@@ -56,7 +56,7 @@ export const ArrayNumericType: DataType = {
  * @param sign the sign of the number
  * @return String the number as String
  */
-function numberBytesToString(digits: number[], scale: number, weight: number, sign: number): string {
+export function numberBytesToString(digits: number[], scale: number, weight: number, sign: number): string {
   let i: number;
   let d: number;
 


### PR DESCRIPTION
This is useful for implementing a custom reinterpretation of decimals - we use it to build a 'Money' type here: https://gitlab.com/webhare/platform/-/blob/master/whtree/jssdk/whdb/src/types.ts#L29 without having to reinvent this API

(as you can see we also reinterpret some other types, haven't found a nice way to subclass existing postgresql-client classes to accomplish this. it might be quite a difficult API to design where copy/pasting mostly does the same job too)