### PR TITLE
Better typescript definitions + expose DatabaseError

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -130,7 +130,9 @@ export const DataTypeOIDs = {
   _varbit: 1563,
   _uuid: 2951,
   _jsonb: 3807,
-};
+} as const;
+
+type INumericDataTypes = (typeof DataTypeOIDs)[keyof typeof DataTypeOIDs];
 
 export const DataTypeNames = {
   [DataTypeOIDs.bool]: 'bool',
@@ -247,4 +249,6 @@ export const DataTypeNames = {
   [DataTypeOIDs._varbit]: '_varbit',
   [DataTypeOIDs._uuid]: '_uuid',
   [DataTypeOIDs._jsonb]: '_jsonb',
+} as const satisfies {
+  [key in INumericDataTypes]: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export { DatabaseError } from './protocol/database-error.js';
+
 export * from './constants.js';
 export * from './data-type-map.js';
 export * from './types.js';


### PR DESCRIPTION
* Export more precise typings for data types
   This enabled the following:
   
    <img width="658" alt="Screenshot 2024-04-17 at 10 40 06 AM" src="https://github.com/panates/postgresql-client/assets/5187123/2021c541-ae55-4623-b061-52cc83208995">

* Expose the database error so that users can use instanceof checks
   This enabled the following:
    
    <img width="526" alt="Screenshot 2024-04-17 at 10 41 58 AM" src="https://github.com/panates/postgresql-client/assets/5187123/c5b3b196-06c6-434b-9af2-947b5e79d328">
